### PR TITLE
禁用“今日人设”指令后的默认 LLM 回复

### DIFF
--- a/main.py
+++ b/main.py
@@ -111,6 +111,8 @@ class LoveFormulaPlugin(Star):
         group_id = event.message_obj.group_id
         user_id = event.message_obj.sender.user_id
         nickname = event.message_obj.sender.nickname
+        # Disable default LLM reply for this command.
+        event.should_call_llm(True)
 
         # 0. 检查是否为指定分析（被 at 的人）
         targeted_user_id = None


### PR DESCRIPTION
- 在 cmd_love_profile 入口处调用 event.should_call_llm(True)，阻止默认 LLM 接管
- 保持指令生成报告图片的现有流程不变
- 目的：只输出报告，不再多一次 LLM 回复

## Summary by Sourcery

Bug Fixes:
- Prevent the default LLM from generating an additional reply when the love profile command is used.